### PR TITLE
Adding additional quality-of-life functions.

### DIFF
--- a/MazeBuilder.py
+++ b/MazeBuilder.py
@@ -420,6 +420,13 @@ def parse_wall_data(line):
         print(f"Invalid line format: {line}")
         return None
 
+# Swaps the width and height of the block being placed, effectively "rotating" it by 90 degrees.
+def rotate_block(event):
+    temp_var = width_var.get()
+    width_var.set(height_var.get())
+    height_var.set(temp_var)
+    
+root.bind("<r>", rotate_block)    
 
 
 def upload_and_generate_walls():

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ SELECTING & DELETING
 - Select any of the instances listed on the right. It'll highlight the corresponding wall on the screen so you know what walls you are about to delete. 
 - After selecting an instance and the corresponding wall is highlighted, click the 'Delete selected' button.
 
-- The code also supports Ctrl + Z undo for misplaced blocks. 
+- Ctrl + Z will undo the last action, if it was to delete a block, it will restore the deleted block. If it was to place a block, it will then delete the block.
 
 UPLOADING
 - If you want to upload your own walls to the editor, use the UPLOAD DATA BUTTON. This takes a txt file containing examples like:

--- a/README.md
+++ b/README.md
@@ -24,9 +24,9 @@ insertAndSetFirstWall(&head, 1, 535, 465, 100, 10);
 ### Rotating
 - The block that you are currently holding can be rotated with `r`. This will swap its width and height. Useful for quickly building walls.
 
-### Undo 
-- Ctrl + Z will undo the last action, if it was to delete a block, it will restore the deleted block. If it was to place a block, it will then delete the block.
-- Re-doing (using Ctrl + y) will be added soon.
+### Undo and Redo
+- `Ctrl + z` will undo the last action, if it was to delete a block, it will restore the deleted block. If it was to place a block, it will then delete the block.
+- `Ctrl + y` will redo the last undone action (using `Ctrl + z`). Be careful, because if any action is taken after undoing, you will not be able to redo anymore.
 
 ### Loading
 - If you want to load your own walls to the editor, use the UPLOAD DATA BUTTON. This takes a txt file containing examples like:

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ insertAndSetFirstWall(&head, 1, 535, 465, 100, 10);
 Original code written by Elvis Nguyen with assistance from chatGPT 4
 
 
-Modified by Isa
+[Mlemko](https://github.com/mlemko) - Added undo, redo and rotation functionality.
 
 
 [Mudit-B](https://github.com/Mudit-B) - Provided Added Ctrl + Z, Clipboard functionality and fixed various issues

--- a/README.md
+++ b/README.md
@@ -17,16 +17,19 @@ insertAndSetFirstWall(&head, 1, 535, 465, 100, 10);
 // and so on...
 ```
 
-### SELECTING & DELETING
+### Selecting & Deleting
 - Select any of the instances listed on the right. It'll highlight the corresponding wall on the screen so you know what walls you are about to delete. 
 - After selecting an instance and the corresponding wall is highlighted, click the 'Delete selected' button.
 
-### UNDO 
+### Rotating
+- The block that you are currently holding can be rotated with `r`. This will swap its width and height. Usefull for quickly building walls.
+
+### Undo 
 - Ctrl + Z will undo the last action, if it was to delete a block, it will restore the deleted block. If it was to place a block, it will then delete the block.
 - Re-doing (using Ctrl + y) will be added soon.
 
-### UPLOADING
-- If you want to upload your own walls to the editor, use the UPLOAD DATA BUTTON. This takes a txt file containing examples like:
+### Loading
+- If you want to load your own walls to the editor, use the UPLOAD DATA BUTTON. This takes a txt file containing examples like:
 ```C
 insertAndSetFirstWall(&head, 0, 625, 375, 10, 100);
 insertAndSetFirstWall(&head, 1, 535, 465, 100, 10);

--- a/README.md
+++ b/README.md
@@ -1,12 +1,9 @@
-MazeBuilderV1
-A mazebuilder GUI because too lazy to make maze myself
+# MazeBuilderFork
+A mazebuilder GUI, but with a few additional QOL-tweaks. This version features a fully-functional undo system, alongside rotating blocks.
 
-Despite being a relatively simple GUI, this is the first time I've developed a functional GUI so ChatGPT was a massive help in guiding me through using tkinter
-The code is not perfect, it is just a basic tool for you to creatively explore maze building because its a massive hassle to hardcode massive/complex mazes
-
-HOW TO USE
+## How to Use
 - Make sure python version is fully updated
-- Run the WallGui.py program using any IDE like VSCODE
+- Run the WallGui.py program using `python WallGui.py`
 - Set your canvas size
 - Click on the screen to place a wall
 - Customise the wall using the width and height sliders
@@ -14,47 +11,52 @@ HOW TO USE
 - The txt file will be in the directory next to the WallGUI.py file
 
 The contents of the txt file will kinda look like 
-
+```C
 insertAndSetFirstWall(&head, 0, 625, 375, 10, 100);
-
 insertAndSetFirstWall(&head, 1, 535, 465, 100, 10);
+// and so on...
+```
 
-SELECTING & DELETING
+### SELECTING & DELETING
 - Select any of the instances listed on the right. It'll highlight the corresponding wall on the screen so you know what walls you are about to delete. 
 - After selecting an instance and the corresponding wall is highlighted, click the 'Delete selected' button.
 
+### UNDO 
 - Ctrl + Z will undo the last action, if it was to delete a block, it will restore the deleted block. If it was to place a block, it will then delete the block.
+- Re-doing (using Ctrl + y) will be added soon.
 
-UPLOADING
+### UPLOADING
 - If you want to upload your own walls to the editor, use the UPLOAD DATA BUTTON. This takes a txt file containing examples like:
-
+```C
 insertAndSetFirstWall(&head, 0, 625, 375, 10, 100);
-
 insertAndSetFirstWall(&head, 1, 535, 465, 100, 10);
-
 insertAndSetFirstWall(&head, 2, 445, 465, 100, 10);
+// etc...
+```
+## TROUBLESHOOTING
 
-TROUBLESHOOTING
-
-Uploaded maze is not fitting 
+#### Uploaded maze is not fitting 
 - Make sure to set your canvas width and height first 
 
-Blocks arent being placed down 
+#### Blocks arent being placed down 
 - Try keeping the GUI windowed and not FULLSCREEN. 
 
-Uploaded file is not being read; 
+#### Uploaded file is not being read; 
 - the txt file must be in the exact format as the output file. Containing only lines of
-
+```C
 insertAndSetFirstWall(&head, 0, 625, 375, 10, 100);
-
 insertAndSetFirstWall(&head, 1, 535, 465, 100, 10);
+```
 
-Blocks are hard to match up or align
+### Blocks are hard to match up or align
 - Adjust the snap scale to 5, 10 or 15
 
-
-#Code written by Elvis Nguyen with assistance from chatGPT 4
-
 ## Contributors
+Original code written by Elvis Nguyen with assistance from chatGPT 4
+
+
+Modified by Isa
+
+
 [Mudit-B](https://github.com/Mudit-B) - Provided Added Ctrl + Z, Clipboard functionality and fixed various issues
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ insertAndSetFirstWall(&head, 1, 535, 465, 100, 10);
 - After selecting an instance and the corresponding wall is highlighted, click the 'Delete selected' button.
 
 ### Rotating
-- The block that you are currently holding can be rotated with `r`. This will swap its width and height. Usefull for quickly building walls.
+- The block that you are currently holding can be rotated with `r`. This will swap its width and height. Useful for quickly building walls.
 
 ### Undo 
 - Ctrl + Z will undo the last action, if it was to delete a block, it will restore the deleted block. If it was to place a block, it will then delete the block.


### PR DESCRIPTION
This pull request adds a few different functions to the base MazeBuilder.

- Using `Ctrl+z` now undoes the previous action, whether it is placing a block, deleting a block, or deleting the whole canvas.
    - This is changed from `Ctrl+z` simply deleting the last block in the list.
- Using `Ctrl+y` will redo the previous "undone" action (exclusively from `Ctrl+z` mentioned above).
- Pressing `r` will now swap the current block's width and height, effectively rotating it by 90 degrees.